### PR TITLE
Migrate from google-generativeai to google-genai SDK.

### DIFF
--- a/backend/nature_go/generation/gemini.py
+++ b/backend/nature_go/generation/gemini.py
@@ -1,14 +1,9 @@
 import os
-import google.generativeai as genai
-CONFIGURED = False
+from google import genai
+from google.genai import types
 
-def configure():
-    google_api_key = os.environ.get('GOOGLE_API_KEY', None)
-    genai.configure(api_key=google_api_key)
-    CONFIGURED = True
+client = genai.Client()
 
-def generate_text(contents, model_name='models/gemini-1.5-flash-latest'):
-    if not CONFIGURED: configure()
-    model = genai.GenerativeModel(model_name=model_name, generation_config={"response_mime_type": "application/json"})
-    response = model.generate_content(contents)
+def generate_text(contents, model_name='gemini-2.0-flash'):
+    response = client.models.generate_content(model=model_name, contents=contents, config=types.GenerateContentConfig(response_mime_type="application/json"))
     return response.text

--- a/backend/nature_go/requirements.txt
+++ b/backend/nature_go/requirements.txt
@@ -8,7 +8,7 @@ pandas
 requests
 Pillow
 gunicorn
-google-generativeai
+google-genai
 wikipedia
 beautifulsoup4
 python-dotenv


### PR DESCRIPTION
This commit updates the codebase to use the new `google-genai` package, replacing the deprecated `google-generativeai`.

Changes include:
- Updated `backend/nature_go/generation/gemini.py` to use the new `google.genai.Client` and its methods for content generation.
- Changed the default model to `gemini-2.0-flash`.
- Updated `backend/nature_go/requirements.txt` to specify `google-genai`.