### PR TITLE
Migrate identification module to new google.genai SDK

### DIFF
--- a/backend/nature_go/observation/views.py
+++ b/backend/nature_go/observation/views.py
@@ -15,7 +15,7 @@ from generation.gemini import generate_text
 from generation.description_generation import generate_descriptions
 from generation.prompts import description_prompt
 from user_profile.signals import xp_gained
-from nature_go.generation.gemini import generate_illustration
+from generation.gemini import generate_illustration
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This commit updates `backend/nature_go/identification/gemini.py` to use the `google.genai` Python SDK instead of the older `google.generativeai` SDK.

Changes include:
- Updated import statements from `google.generativeai` to `google.genai`.
- Modified client initialization to use `genai.Client()`.
- Adapted the `gemini_identify_few_shot` function to use `client.models.generate_content`.