### PR TITLE
Add delete_species_illustrations management command

### DIFF
--- a/backend/nature_go/observation/management/commands/delete_species_illustrations.py
+++ b/backend/nature_go/observation/management/commands/delete_species_illustrations.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+from backend.nature_go.observation.models import Species
+
+class Command(BaseCommand):
+    help = 'Deletes all illustration and illustration_transparent files from all Species objects.'
+
+    def handle(self, *args, **options):
+        species_list = Species.objects.all()
+        for species in species_list:
+            if species.illustration:
+                species.illustration.delete(save=False)
+                self.stdout.write(self.style.SUCCESS(f"Deleted illustration for {species}"))
+            if species.illustration_transparent:
+                species.illustration_transparent.delete(save=False)
+                self.stdout.write(self.style.SUCCESS(f"Deleted illustration_transparent for {species}"))
+            species.save()
+        self.stdout.write(self.style.SUCCESS("Successfully deleted all species illustrations."))

--- a/backend/nature_go/observation/tests.py
+++ b/backend/nature_go/observation/tests.py
@@ -1,3 +1,45 @@
+import os
 from django.test import TestCase
+from django.core.management import call_command
+from django.core.files.uploadedfile import SimpleUploadedFile
+from .models import Species
 
-# Create your tests here.
+
+class DeleteSpeciesIllustrationsCommandTest(TestCase):
+    def setUp(self):
+        # Create dummy illustration files
+        self.illustration_file = SimpleUploadedFile(
+            name='illustration.jpg',
+            content=b'dummy content for illustration',
+            content_type='image/jpeg'
+        )
+        self.illustration_transparent_file = SimpleUploadedFile(
+            name='illustration_transparent.png',
+            content=b'dummy content for transparent illustration',
+            content_type='image/png'
+        )
+
+        # Create a Species object with illustrations
+        self.species = Species.objects.create(
+            name='Test Species',
+            illustration=self.illustration_file,
+            illustration_transparent=self.illustration_transparent_file
+        )
+        # Store file paths
+        self.illustration_path = self.species.illustration.path
+        self.illustration_transparent_path = self.species.illustration_transparent.path
+
+    def test_delete_illustrations_command(self):
+        # Call the management command
+        call_command('delete_species_illustrations')
+
+        # Refresh the species object from the database
+        self.species.refresh_from_db()
+
+        # Assert that the illustration fields are empty
+        self.assertFalse(self.species.illustration)
+        self.assertFalse(self.species.illustration_transparent)
+
+        # Assert that the files no longer exist on the file system
+        self.assertFalse(os.path.exists(self.illustration_path))
+        self.assertFalse(os.path.exists(self.illustration_transparent_path))


### PR DESCRIPTION
This commit introduces a new management command `delete_species_illustrations` that allows for the deletion of all `illustration` and `illustration_transparent` files from all `Species` objects in the database.

The command iterates through each `Species` instance, removes the associated illustration files if they exist, and saves the changes.

Unit tests have been added to verify the command's functionality, ensuring that files are correctly deleted from both the model instances and the filesystem.