### PR TITLE
feat: Implement audio description playback in SpeciesDetail

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "axios": "^1.4.0",
         "cors-anywhere": "^0.4.4",
         "expo": "^53.0.0",
+        "expo-audio": "^0.4.6",
         "expo-camera": "~16.1.8",
         "expo-font": "~13.3.1",
         "expo-image": "~2.3.0",
@@ -4284,6 +4285,16 @@
         "@expo/image-utils": "^0.7.4",
         "expo-constants": "~17.1.5"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-audio": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-0.4.6.tgz",
+      "integrity": "sha512-/pgz0AnQHnyJWkPfTp/3gBDib6FZYnscpktFZgmPeTeCK8KkPV4+eV2oEDDbSe2ngUrqDA0WVO4MX2Mfeec9ZA==",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.4.0",
     "cors-anywhere": "^0.4.4",
     "expo": "^53.0.0",
+    "expo-audio": "^0.4.6",
     "expo-camera": "~16.1.8",
     "expo-font": "~13.3.1",
     "expo-image": "~2.3.0",


### PR DESCRIPTION
Adds audio playback functionality to the Species Detail screen.

- If a species has an `audio_description` URL, the audio will autoplay.
- A play/pause button is displayed in the top-right corner of the description text area, allowing you to control playback.
- The button icon dynamically changes to reflect loading, playing, or paused states.

This feature utilizes the `expo-audio` library (with the `useAudioPlayer` hook) for audio handling, replacing a previous attempt that assumed an `expo-av`-like API. The implementation includes state management for playback, UI updates for the button, and relies on `useAudioPlayer` for resource management.