### PR TITLE
feat: Display activity indicator during audio generation

### DIFF
--- a/frontend/screens/SpeciesDetail.js
+++ b/frontend/screens/SpeciesDetail.js
@@ -291,14 +291,20 @@ export default function SpeciesDetailScreen({ navigation, route }) {
                     {speciesDetails.rarity ? <View style={styles.rarityContainer}><RarityBadge rarity={speciesDetails.rarity} /></View> : null}
 
                     <View style={styles.descriptionAreaWrapper}>
-                        {speciesDetails.audio_description && player && (
-                            <TouchableOpacity onPress={handlePlayPause} style={styles.audioButtonDescriptionArea}>
-                                {(audioStatus.playing && !audioStatus.didJustFinish) ? (
-                                    <Ionicons name="pause-circle" size={26} color="#331100" />
-                                ) : (
-                                    <Ionicons name="play-circle" size={26} color="#331100" />
-                                )}
+                        {isGeneratingAudioContent ? (
+                            <TouchableOpacity style={styles.audioButtonDescriptionArea}>
+                                <ActivityIndicator size="small" color="#331100" />
                             </TouchableOpacity>
+                        ) : (
+                            speciesDetails.audio_description && player && (
+                                <TouchableOpacity onPress={handlePlayPause} style={styles.audioButtonDescriptionArea}>
+                                    {(audioStatus.playing && !audioStatus.didJustFinish) ? (
+                                        <Ionicons name="pause-circle" size={26} color="#331100" />
+                                    ) : (
+                                        <Ionicons name="play-circle" size={26} color="#331100" />
+                                    )}
+                                </TouchableOpacity>
+                            )
                         )}
                         <FlatList
                             vertical


### PR DESCRIPTION
This commit introduces an activity indicator in the SpeciesDetail screen. The indicator replaces the play/pause button while the audio description is being generated, providing visual feedback to you.

The changes include:
- Conditional rendering of the ActivityIndicator or play/pause button based on the `isGeneratingAudioContent` state.
- Styling the ActivityIndicator to match the existing button's position and appearance.