### PR TITLE
feat: Add random slug to illustration filenames

### DIFF
--- a/backend/nature_go/generation/illustration_generation.py
+++ b/backend/nature_go/generation/illustration_generation.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 import typing as tp
+import uuid
 from django.core.files.base import ContentFile, File
 from PIL import Image
 import math
@@ -27,7 +28,8 @@ def generate_illustration(generate_image: tp.Callable, species: Species) -> bool
     raw_bytes = generate_image(prompt_text)
 
     if raw_bytes:
-        file_name = f"{scientific_name.replace(' ', '_')}_illustration.png"
+        random_slug = uuid.uuid4().hex[:8]
+        file_name = f"{scientific_name.replace(' ', '_')}_{random_slug}_illustration.png"
         species.illustration.save(file_name, ContentFile(raw_bytes), save=False)
         species.save()
         return True
@@ -45,7 +47,8 @@ def generate_illustration_transparent(species) -> bool:
     illustration_transparent = remove_background_by_pixel(illustration)
     bytes_io = BytesIO()
     illustration_transparent.save(bytes_io, 'PNG')  
-    file_name = f"{scientific_name.replace(' ', '_')}_illustration_transparent.png"
+    random_slug = uuid.uuid4().hex[:8]
+    file_name = f"{scientific_name.replace(' ', '_')}_{random_slug}_illustration_transparent.png"
     species.illustration_transparent.save(file_name, File(bytes_io), save=False)
     species.save()
     return True

--- a/backend/nature_go/observation/tests.py
+++ b/backend/nature_go/observation/tests.py
@@ -118,3 +118,63 @@ class DeleteSpeciesDescriptionQuizCommandTest(TestCase): # Renamed class
 
         # Ensure species themselves are not deleted
         self.assertEqual(Species.objects.count(), 2)
+
+# Added imports for IllustrationFilenameTest
+from io import BytesIO
+import re
+from unittest.mock import patch, MagicMock
+from generation.illustration_generation import generate_illustration, generate_illustration_transparent
+# Species, TestCase, and ContentFile are already imported or available from above.
+
+class IllustrationFilenameTest(TestCase):
+    def setUp(self):
+        self.species = Species.objects.create(
+            scientificNameWithoutAuthor='Test Species Name',
+            type=Species.PLANT_TYPE,
+            commonNames=['Test Plant']
+        )
+        self.mock_generate_image = MagicMock(return_value=b'dummy image data')
+
+    def tearDown(self):
+        Species.objects.all().delete()
+
+    def test_generate_illustration_filename_with_slug(self):
+        success = generate_illustration(self.mock_generate_image, self.species)
+        self.assertTrue(success, "generate_illustration should return True on success")
+
+        self.assertIsNotNone(self.species.illustration.name, "Illustration name should be set.")
+        self.species.refresh_from_db()
+        saved_filename = self.species.illustration.name
+
+        expected_pattern = r"^species/illustration/Test_Species_Name_[a-f0-9]{8}_illustration\.png$"
+        self.assertIsNotNone(re.match(expected_pattern, saved_filename),
+                                 f"Filename '{saved_filename}' does not match pattern '{expected_pattern}'")
+
+    def test_generate_illustration_transparent_filename_with_slug(self):
+        initial_illustration_name = 'Test_Species_Name_dummy_illustration.png'
+        initial_dummy_content = ContentFile(b'dummy data for initial illustration', name=initial_illustration_name)
+        self.species.illustration.save(initial_illustration_name, initial_dummy_content, save=True)
+        self.species.refresh_from_db()
+
+        with patch('generation.illustration_generation.Image.open') as mock_image_open, \
+             patch('generation.illustration_generation.remove_background_by_pixel') as mock_remove_bg:
+
+            mock_img_instance = MagicMock()
+            mock_img_instance.convert.return_value = mock_img_instance
+            mock_img_instance.getdata.return_value = []
+            mock_img_instance.getpixel.return_value = (0,0,0,0)
+            mock_img_instance.save = MagicMock()
+
+            mock_image_open.return_value = mock_img_instance
+            mock_remove_bg.return_value = mock_img_instance
+
+            success = generate_illustration_transparent(self.species)
+            self.assertTrue(success, "generate_illustration_transparent should return True on success")
+
+        self.assertIsNotNone(self.species.illustration_transparent.name, "Transparent illustration name should be set.")
+        self.species.refresh_from_db()
+        saved_filename = self.species.illustration_transparent.name
+
+        expected_pattern = r"^species/illustration_transparent/Test_Species_Name_[a-f0-9]{8}_illustration_transparent\.png$"
+        self.assertIsNotNone(re.match(expected_pattern, saved_filename),
+                                 f"Filename '{saved_filename}' does not match pattern '{expected_pattern}'")


### PR DESCRIPTION
This change modifies the filename generation for illustrations to include a random 8-character hexadecimal slug. This helps prevent potential filename collisions and makes filenames more unique.

The changes were made in the `generate_illustration` and `generate_illustration_transparent` functions in
`backend/nature_go/generation/illustration_generation.py`.

The new filename formats are:
- `{scientific_name_slug}_{random_slug}_illustration.png`
- `{scientific_name_slug}_{random_slug}_illustration_transparent.png`

Unit tests have been added to `backend/nature_go/observation/tests.py` to verify the new filename formats, ensuring the slug is present and correctly formatted. The tests mock the image generation and file saving processes to focus specifically on the filename logic.