### PR TITLE
Refactor: Split illustration generation into two endpoints

### DIFF
--- a/backend/nature_go/observation/urls.py
+++ b/backend/nature_go/observation/urls.py
@@ -13,6 +13,7 @@ urlpatterns = format_suffix_patterns([
     path('<int:pk>/observations/', views.SpeciesObservationsList.as_view(), name='species-observations-list'),
     path('<int:pk>/generate_descriptions/', views.SpeciesGenerateDescription.as_view(), name='species-generate-descriptions'),
     path('<int:pk>/generate_illustration/', views.GenerateIllustrationView.as_view(), name='species-generate-illustration'),
+    path('<int:pk>/generate_transparent_illustration/', views.GenerateTransparentIllustrationView.as_view(), name='species-generate-transparent-illustration'),
     path('<int:pk>/generate_audio_description/', views.GenerateAudioDescriptionView.as_view(), name='species-generate-audio-description'),
     path('observation/', views.ObservationListCreate.as_view(), name='observations-list-create'),
     path('observation/<int:pk>/', views.ObservationUpdate.as_view(), name='observations-update'),

--- a/backend/nature_go/observation/views.py
+++ b/backend/nature_go/observation/views.py
@@ -226,13 +226,26 @@ class GenerateIllustrationView(generics.GenericAPIView):
     def post(self, request, *args, **kwargs):
         species = self.get_object()
         success = generate_illustration(generate_image=generate_image, species=species)
-        transparent_success = generate_illustration_transparent(remove_background_fn=remove_background, species=species)
-        success = success or transparent_success
         if success:
             serializer = self.get_serializer(species)
             return Response(serializer.data, status=status.HTTP_200_OK)
         else:
             return Response({'error': 'Failed to generate illustration'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+class GenerateTransparentIllustrationView(generics.GenericAPIView):
+    queryset = Species.objects.all()
+    serializer_class = SpeciesSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        species = self.get_object()
+        success = generate_illustration_transparent(remove_background_fn=remove_background, species=species)
+        if success:
+            serializer = self.get_serializer(species)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        else:
+            return Response({'error': 'Failed to generate transparent illustration'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 
 class GenerateAudioDescriptionView(generics.GenericAPIView):


### PR DESCRIPTION
This change separates the generation of standard and transparent illustrations into two distinct API endpoints and view functions.

Previously, a single endpoint handled both, causing delays as transparent illustration generation can be slow.

The following changes were made:

Backend:
- Modified `GenerateIllustrationView` in `observation/views.py` to only handle standard illustration generation.
- Added a new `GenerateTransparentIllustrationView` in `observation/views.py` to specifically handle transparent illustration generation.
- Updated `observation/urls.py` to include a new URL pattern `/species/<pk>/generate_transparent_illustration/` pointing to the new view.
- Ensured `generation/illustration_generation.py` functions correctly handle cases where base illustrations might not yet exist for transparent versions.

Frontend:
- Added `SPECIES_GENERATE_TRANSPARENT_ILLUSTRATION_URL` in `screens/SpeciesDetail.js`.
- Created a new `generateTransparentIllustration` function to call this new endpoint.
- Updated the `useEffect` hook in `screens/SpeciesDetail.js` to call both `generateIllustration` and then `generateTransparentIllustration`, allowing the primary illustration to be available sooner.